### PR TITLE
Fix Base64url->Base64 conversion

### DIFF
--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -15,9 +15,10 @@ export function decodeToken(token: string): Object | null {
     // data about the expiration time
     const payload: string = token.split(".")[1];
     // determine the padding characters required for the base64 string
-    const padding: string = "=".repeat((4 - payload.length % 4) % 4);
+    const padding: string = "=".repeat((4 - (payload.length % 4)) % 4);
     // convert the base64url string to a base64 string
-    const base64: string = payload.replace("-", "+").replace("_", "/") + padding;
+    const base64: string =
+      payload.replace("-", "+").replace("_", "/") + padding;
     // decode and parse to json
     const decoded = JSON.parse(atob(base64));
 

--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -14,8 +14,10 @@ export function decodeToken(token: string): Object | null {
     // payload ( index 1 ) has the data stored and
     // data about the expiration time
     const payload: string = token.split(".")[1];
-    // handle unicode parsing issues between atob and JWT base64 format
-    const base64: string = payload.replace("-", "+").replace("_", "/");
+    // determine the padding characters required for the base64 string
+    const padding: string = "=".repeat((4 - payload.length % 4) % 4);
+    // convert the base64url string to a base64 string
+    const base64: string = payload.replace("-", "+").replace("_", "/") + padding;
     // decode and parse to json
     const decoded = JSON.parse(atob(base64));
 


### PR DESCRIPTION
atob() requires an ascii string that was generated from btoa(), which
generates strings whose length is a multiple of 4. This fix ensures that
the payload is in a form that can be decoded by atob().